### PR TITLE
Add and configure "docs" dependencies for documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
         run: brew install swig
 
       - run: uv python install ${{ matrix.python-version }}
-      - run: uv sync --all-extras --frozen
+      - run: make
       - run: make test
     continue-on-error: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ build:
   jobs:
     post_install:
       - pip install uv
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras -group docs --link-mode=copy --frozen
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs --link-mode=copy --frozen

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ build:
   jobs:
     post_install:
       - pip install uv
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --all-groups --link-mode=copy --frozen
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras -group docs --link-mode=copy --frozen

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,9 @@ dev = [
     "chess",
 
     "luxai-s3",
+
+]
+docs = [
     "sybil[pytest]",
     "sphinx>=8.2.0; python_version >= '3.11'",
     "sphinx>=7.0.0; python_version < '3.11'",

--- a/uv.lock
+++ b/uv.lock
@@ -1802,6 +1802,8 @@ dev = [
     { name = "ruff" },
     { name = "scipy" },
     { name = "shimmy", extra = ["gym-v26"] },
+]
+docs = [
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-rtd-theme" },
@@ -1835,6 +1837,8 @@ dev = [
     { name = "ruff", specifier = ">=0.8.2" },
     { name = "scipy" },
     { name = "shimmy", extras = ["gym-v26"] },
+]
+docs = [
     { name = "sphinx", marker = "python_full_version < '3.11'", specifier = ">=7.0.0" },
     { name = "sphinx", marker = "python_full_version >= '3.11'", specifier = ">=8.2.0" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },


### PR DESCRIPTION
Added a new "docs" group with dependencies like Sphinx and sphinx-rtd-theme to support better documentation management. Adjusted the ReadTheDocs YAML to sync only the "docs" group for clarity and organization. Updated `uv.lock` to reflect these changes.