### PR TITLE
Update ReadTheDocs config to include SWIG installation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,5 +18,6 @@ build:
     python: "3.12"
   jobs:
     post_install:
+      - sudo apt-get install swig
       - pip install uv
       - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs --link-mode=copy --frozen


### PR DESCRIPTION
Added a step to install SWIG during the post-install process to ensure compatibility with project dependencies. This change is necessary for building environments that require SWIG.