### PR TITLE
Update package installer command in ReadTheDocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,6 +18,6 @@ build:
     python: "3.12"
   jobs:
     post_install:
-      - sudo apt-get install swig
+      - apt-get install swig
       - pip install uv
       - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --all-extras --group docs --link-mode=copy --frozen


### PR DESCRIPTION
Replaced "sudo apt-get install" with "apt-get install" to align with recommended practices for ReadTheDocs environments. This ensures compatibility and avoids