### PR TITLE
Update 'uv sync' command in ReadTheDocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,4 @@ build:
   jobs:
     post_install:
       - pip install uv
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs --link-mode=copy --frozen
+      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --only-group  docs --link-mode=copy --frozen


### PR DESCRIPTION
Modified the 'uv sync' command to include the '--only-group' flag for better precision during synchronization. This ensures that only the specified group 'docs' is processed, improving clarity and reducing potential issues.