### PR TITLE
Update API docs to exclude indexing in documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,26 +8,25 @@ Probability Spaces
 
 .. automodule:: prob_spaces
    :members:
-   :undoc-members:
-   :show-inheritance:
+   :no-index:
+
 
 Converter
 ---------
 
 .. automodule:: prob_spaces.converter
    :members:
-   :undoc-members:
-   :show-inheritance:
+   :no-index:
+
 
 Distributions
 -------------
 
 .. automodule:: prob_spaces.dists
    :members:
-   :undoc-members:
-   :show-inheritance:
+   :no-index:
+
 
 .. automodule:: prob_spaces.dists.categorical
    :members:
-   :undoc-members:
-   :show-inheritance:
+   :no-index:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,15 @@ authors = [
 ]
 license = { text = "MIT" }
 readme = "README.md"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
 requires-python = ">=3.10"
 
 keywords = [


### PR DESCRIPTION
Replaced `:undoc-members:` and `:show-inheritance:` with `:no-index:` to prevent indexing of certain modules in the documentation. This change improves clarity by removing less relevant or hidden details from the API reference.