### PR TITLE
Support Dict & Tuple spaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
+enable-beta-ecosystems: true
+
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Code Checks](https://github.com/DanielAvdar/prob-spaces/actions/workflows/code-checks.yml/badge.svg)](https://github.com/DanielAvdar/prob-spaces/actions/workflows/code-checks.yml)
 [![codecov](https://codecov.io/gh/DanielAvdar/prob-spaces/graph/badge.svg?token=N0V9KANTG2)](https://codecov.io/gh/DanielAvdar/prob-spaces)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
-
+![Last Commit](https://img.shields.io/github/last-commit/DanielAvdar/prob-spaces/main)
 **prob-spaces** is a Python package that allows you to create probability distributions from Gymnasium spaces.
 It provides a simple and intuitive interface for working with various probability spaces in reinforcement learning
 environments.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,11 +41,12 @@ environments.
    :maxdepth: 1
    :caption: Usage:
 
+   ./modules/converter
    ./modules/discrete
    ./modules/multi_discrete
    ./modules/box
    ./modules/dict
-   ./modules/converter
+   ./modules/tuple
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,7 +28,7 @@ environments.
 .. image:: https://img.shields.io/badge/ubuntu-blue?logo=apple
    :alt: MacOS
 
-.. image:: https://img.shields.io/github/last-commit/ivanovnikita/prob-spaces/main
+.. image:: https://img.shields.io/github/last-commit/DanielAvdar/prob-spaces/main
    :alt: Last Commit
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,9 @@ environments.
 .. image:: https://img.shields.io/badge/ubuntu-blue?logo=apple
    :alt: MacOS
 
+.. image:: https://img.shields.io/github/last-commit/ivanovnikita/prob-spaces/main
+   :alt: Last Commit
+
 
 
 .. toctree::

--- a/docs/source/modules/dict.rst
+++ b/docs/source/modules/dict.rst
@@ -20,11 +20,11 @@ API Reference
    :show-inheritance:
 
 Usage Examples
--------------
+--------------
 
 Basic usage:
 
-
+.. code-block:: python
 
     import torch as th
     import gymnasium as gym

--- a/docs/source/modules/discrete.rst
+++ b/docs/source/modules/discrete.rst
@@ -12,7 +12,7 @@ Overview
 It is useful for environments with a fixed number of distinct actions.
 
 API Reference
-------------
+-------------
 
 .. autoclass:: prob_spaces.discrete.DiscreteDist
    :members: __call__
@@ -20,7 +20,7 @@ API Reference
    :show-inheritance:
 
 Usage Examples
--------------
+--------------
 
 Basic usage:
 

--- a/docs/source/modules/multi_discrete.rst
+++ b/docs/source/modules/multi_discrete.rst
@@ -21,14 +21,14 @@ API Reference
    :show-inheritance:
 
 Key Attributes
--------------
+--------------
 
 * ``nvec``: Array of integers representing the number of values for each discrete variable
 * ``start``: Optional starting indices for each variable
 * ``internal_mask``: Automatically generated mask to ensure valid actions
 
 Usage Examples
--------------
+--------------
 
 Basic usage:
 

--- a/docs/source/modules/tuple.rst
+++ b/docs/source/modules/tuple.rst
@@ -1,0 +1,79 @@
+.. _tuple:
+
+Tuple Space
+===========
+
+The ``TupleDist`` class extends the Gymnasium Tuple space to handle combinations of multiple sub-spaces, generating composite probability distributions.
+
+Overview
+--------
+
+``TupleDist`` is useful when working with action spaces that require different sub-spaces organized in a tuple structure. It generates distributions corresponding to each sub-space, which can be either discrete or continuous.
+
+API Reference
+-------------
+
+.. autoclass:: prob_spaces.tuple.TupleDist
+   :members: __call__
+   :undoc-members:
+   :show-inheritance:
+
+Usage Examples
+--------------
+
+Basic usage with discrete and continuous spaces:
+
+.. code-block:: python
+
+    import torch as th
+    from prob_spaces.tuple import TupleDist
+    from prob_spaces.discrete import DiscreteDist
+    from prob_spaces.box import BoxDist
+
+    # Create a tuple space consisting of discrete and continuous components
+    space = TupleDist(spaces=(
+        DiscreteDist(n=3),
+        BoxDist(low=-1, high=1, shape=(2,))
+    ))
+
+    # Define probabilities
+    probs = (
+        th.tensor([0.1, 0.6, 0.3]),                     # Probabilities for discrete component
+        (th.tensor([0.0, 0.0]), th.tensor([0.5, 0.5]))  # Mean and variance for continuous component
+    )
+
+    # Create the tuple of distributions
+    distributions = space(prob=probs)
+
+    # Sample from the distribution tuple
+    samples = [dist.sample() for dist in distributions]
+
+With masking for discrete spaces:
+
+.. code-block:: python
+
+    import torch as th
+    from prob_spaces.tuple import TupleDist
+    from prob_spaces.discrete import DiscreteDist
+    from prob_spaces.box import BoxDist
+
+    space = TupleDist(spaces=(
+        DiscreteDist(n=4),
+        BoxDist(low=-2, high=2, shape=(3,))
+    ))
+
+    probs = (
+        th.tensor([0.25, 0.25, 0.25, 0.25]),                    # Probabilities for discrete component
+        (th.tensor([0.0, 0.0, 0.0]), th.tensor([1.0, 1.0, 1.0])) # Mean, variance for continuous component
+    )
+
+    # Apply mask to discrete component to disallow specific actions
+    masks = (
+        th.tensor([1, 0, 1, 1], dtype=th.bool),
+        None  # No mask for the continuous component
+    )
+
+    distributions = space(prob=probs, mask=masks)
+
+    # Sampling respecting masks
+    samples = [dist.sample() for dist in distributions]

--- a/prob_spaces/converter.py
+++ b/prob_spaces/converter.py
@@ -4,6 +4,7 @@ from prob_spaces.box import BoxDist
 from prob_spaces.dict import DictDist
 from prob_spaces.discrete import DiscreteDist
 from prob_spaces.multi_discrete import MultiDiscreteDist
+from prob_spaces.tuple import TupleDist
 
 Spaces = gym.spaces.Box | gym.spaces.Discrete | gym.spaces.MultiDiscrete
 DistSpaces = BoxDist | DiscreteDist | MultiDiscreteDist | None
@@ -37,6 +38,11 @@ def convert_to_prob_space(action_space: Spaces) -> DistSpaces:
         space_dist = DictDist()
         for k, v in action_space.spaces.items():
             space_dist[k] = convert_to_prob_space(v)
+    elif isinstance(action_space, gym.spaces.Tuple):
+        space_list = []
+        for v in action_space.spaces:
+            space_list.append(convert_to_prob_space(v))
+        space_dist = TupleDist(space_list)
     else:
         raise NotImplementedError(f"Action space {type(action_space)} not supported")
 

--- a/prob_spaces/dict.py
+++ b/prob_spaces/dict.py
@@ -19,9 +19,9 @@ class DictDist(spaces.Dict):
         for key, s in self.spaces.items():
             if isinstance(s, spaces.Discrete) or isinstance(s, spaces.MultiDiscrete):
                 space_mask = mask.get(key, None) if isinstance(mask, dict) else None
-                dist_dict[key] = s(prob[key], space_mask)
+                dist_dict[key] = s(prob[key], space_mask)  # type: ignore
             else:
-                dist_dict[key] = s(
+                dist_dict[key] = s(  # type: ignore
                     prob[key][0],
                     prob[key][1],
                 )

--- a/prob_spaces/dict.py
+++ b/prob_spaces/dict.py
@@ -17,7 +17,13 @@ class DictDist(spaces.Dict):
         mask = mask or {}
 
         for key, s in self.spaces.items():
-            space_mask = mask.get(key, None)
-            dist_dict[key] = s(prob[key], mask=space_mask)  # type: ignore #todo change into prob_spaces type
+            if isinstance(s, spaces.Discrete) or isinstance(s, spaces.MultiDiscrete):
+                space_mask = mask.get(key, None) if isinstance(mask, dict) else None
+                dist_dict[key] = s(prob[key], space_mask)
+            else:
+                dist_dict[key] = s(
+                    prob[key][0],
+                    prob[key][1],
+                )
 
         return dist_dict

--- a/prob_spaces/tuple.py
+++ b/prob_spaces/tuple.py
@@ -1,0 +1,27 @@
+from gymnasium import spaces
+
+
+class TupleDist(spaces.Tuple):
+    def __call__(self, prob: tuple, mask: tuple = None) -> tuple:
+        """
+        Create a tuple of distributions based on input probabilities.
+
+        Args:
+            prob: Tuple of probability tensors for each space.
+            mask: Optional tuple of masks for each space.
+
+        Returns:
+            Tuple of distribution objects.
+        """
+        dist_list = []
+        mask = mask or (None,) * len(self.spaces)
+
+        for i, s in enumerate(self.spaces):
+            space_mask = mask[i]
+
+            if isinstance(s, (spaces.Discrete, spaces.MultiDiscrete)):
+                dist_list.append(s(prob[i], space_mask))
+            else:
+                dist_list.append(s(prob[i][0], prob[i][1]))
+
+        return tuple(dist_list)

--- a/prob_spaces/tuple.py
+++ b/prob_spaces/tuple.py
@@ -20,8 +20,8 @@ class TupleDist(spaces.Tuple):
             space_mask = mask[i]
 
             if isinstance(s, (spaces.Discrete, spaces.MultiDiscrete)):
-                dist_list.append(s(prob[i], space_mask))
+                dist_list.append(s(prob[i], space_mask))  # type: ignore
             else:
-                dist_list.append(s(prob[i][0], prob[i][1]))
+                dist_list.append(s(prob[i][0], prob[i][1]))  # type: ignore
 
         return tuple(dist_list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Education",
 ]
 requires-python = ">=3.10"
 

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,32 +1,43 @@
 import numpy as np
 import pytest
-from gymnasium.spaces import Box, Discrete
+import torch
+from gymnasium.spaces import Box, Dict, Discrete
 
+from prob_spaces import convert_to_prob_space
 from prob_spaces.dict import DictDist
 
-# @pytest.mark.parametrize(
-#     "spaces, probs, masks",
-#     [
-#         (
-#             {"box_space": Box(-1.0, 1.0, (2,)), "discrete_space": Discrete(3)},
-#             {"box_space": np.array([0.2, 0.8]), "discrete_space": np.array([0.1, 0.4, 0.5])},
-#             None,
-#         ),
-#         (
-#             {"box_space": Box(-1.0, 1.0, (3,)), "discrete_space": Discrete(4)},
-#             {"box_space": np.array([0.3, 0.6, 0.1]), "discrete_space": np.array([0.25, 0.25, 0.25, 0.25])},
-#             {"discrete_space": np.array([1, 0, 1, 1])},
-#         ),
-#     ],
-# )
-# def test_dictdist_initialization_and_call(spaces, probs, masks):
-#     dict_dist = DictDist(spaces=spaces)
-#     assert isinstance(dict_dist, DictDist)
-#     assert dict_dist.spaces == spaces
-#
-#     dist_result = dict_dist(prob=probs, mask=masks)
-#     assert isinstance(dist_result, dict)
-#     assert set(dist_result.keys()) == set(spaces.keys())
+
+@pytest.mark.parametrize(
+    "spaces, probs, masks",
+    [
+        (
+            {"box_space": Box(-1.0, 1.0, (2,)), "discrete_space": Discrete(3)},
+            {
+                "box_space": (torch.tensor([0.2, 0.8]), torch.tensor([0.5, 0.5])),
+                "discrete_space": torch.tensor([0.1, 0.4, 0.5]),
+            },
+            None,
+        ),
+        (
+            {"box_space": Box(-1.0, 1.0, (3,)), "discrete_space": Discrete(4)},
+            {
+                "box_space": (torch.tensor([0.3, 0.6, 0.1]), torch.tensor([0.2, 0.5, 0.3])),
+                "discrete_space": torch.tensor([0.25, 0.25, 0.25, 0.25]),
+            },
+            {"discrete_space": torch.tensor([1, 0, 1, 1], dtype=torch.bool)},
+        ),
+    ],
+)
+def test_dictdist_initialization_and_call(spaces, probs, masks):
+    dict_space = Dict(spaces=spaces)
+
+    dict_dist = convert_to_prob_space(dict_space)
+    assert isinstance(dict_dist, DictDist)
+    assert dict_dist.spaces == spaces
+
+    dist_result = dict_dist(prob=probs, mask=masks)
+    assert isinstance(dist_result, dict)
+    assert set(dist_result.keys()) == set(spaces.keys())
 
 
 def test_dictdist_with_invalid_probabilities():

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -1,0 +1,51 @@
+import pytest
+import torch
+from gymnasium.spaces import Box, Discrete, Tuple
+
+from prob_spaces import convert_to_prob_space
+from prob_spaces.tuple import TupleDist
+
+
+@pytest.mark.parametrize(
+    "spaces, probs, masks",
+    [
+        (
+            (Discrete(3), Box(-1.0, 1.0, (2,))),
+            (torch.tensor([0.1, 0.6, 0.3]), (torch.tensor([0.1, 0.9]), torch.tensor([0.2, 0.8]))),
+            (None, None),
+        ),
+        (
+            (Discrete(4), Box(-2.0, 2.0, (3,))),
+            (torch.tensor([0.25, 0.25, 0.25, 0.25]), (torch.tensor([0.3, 0.5, 0.2]), torch.tensor([0.4, 0.4, 0.2]))),
+            (torch.tensor([1, 0, 1, 1], dtype=torch.bool), None),
+        ),
+    ],
+)
+def test_tupledist_initialization_and_call(spaces, probs, masks):
+    tuple_space = Tuple(spaces=spaces)
+
+    tuple_dist = convert_to_prob_space(tuple_space)
+    assert isinstance(tuple_dist, TupleDist)
+    assert tuple_dist.spaces == spaces
+
+    dist_result = tuple_dist(prob=probs, mask=masks)
+    assert isinstance(dist_result, tuple)
+    assert len(dist_result) == len(spaces)
+
+
+def test_tupledist_with_invalid_probabilities():
+    spaces = (Discrete(3), Box(-1.0, 1.0, (2,)))
+    tuple_dist = TupleDist(spaces=spaces)
+
+    invalid_probs = ("invalid", (torch.tensor([0.2, 0.8]), torch.tensor([0.5, 0.5])))
+    with pytest.raises(TypeError):
+        tuple_dist(prob=invalid_probs)
+
+
+def test_tupledist_with_missing_probabilities():
+    spaces = (Discrete(3),)
+    tuple_dist = TupleDist(spaces=spaces)
+
+    missing_probs = ()
+    with pytest.raises(IndexError):
+        tuple_dist(prob=missing_probs)


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and documentation of the `prob-spaces` project. The most important changes include the addition of support for tuple spaces, updates to documentation files, and enhancements to tests.

### Support for Tuple Spaces:
* Added `TupleDist` class to handle combinations of multiple sub-spaces, generating composite probability distributions. (`prob_spaces/tuple.py`)
* Updated `convert_to_prob_space` function to support `gym.spaces.Tuple`. (`prob_spaces/converter.py`)

### Documentation Updates:
* Added new section for `TupleDist` in the documentation with usage examples. (`docs/source/modules/tuple.rst`)
* Added "Last Commit" badge to `README.md`. (`README.md`)
* Updated `index.rst` to include `converter` and reordered modules. (`docs/source/index.rst`)

### Enhancements to Tests:
* Added tests for `TupleDist` initialization and functionality. (`tests/test_tuple.py`)
* Enhanced existing tests for `DictDist` to include more comprehensive scenarios. (`tests/test_dict.py`)

### Minor Improvements:
* Enabled beta ecosystems in Dependabot configuration. (`.github/dependabot.yml`)
* Added new classifiers to `pyproject.toml` for better project categorization. (`pyproject.toml`)