### PR TITLE
Enhance docstrings checks & Fix pre-commit execution on commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ default: install
 
 
 install:
+	uv run pre-commit install
 	uv sync --all-extras --all-groups --frozen
 	uv tool install pre-commit --with pre-commit-uv --force-reinstall
 

--- a/prob_spaces/box.py
+++ b/prob_spaces/box.py
@@ -27,7 +27,14 @@ class BoxDist(spaces.Box):
         self.base_dist = dist or th.distributions.Normal
 
     def transforms(self, device: th.device) -> list:
-        """Return list of transforms to map base distribution to Box bounds."""
+        """Return list of transforms to map base distribution to Box bounds.
+
+        Returns
+        -------
+        list
+            List of transforms to map the base distribution to Box bounds.
+
+        """
         t_low = th.tensor(self.low, device=device)
         t_high = th.tensor(self.high, device=device)
         range_value = t_high - t_low
@@ -48,6 +55,12 @@ class BoxDist(spaces.Box):
         :param scale: A tensor specifying the scale parameters for the base distribution.
         :return: A transformed distribution object derived from the specified base distribution and
             transformations.
+
+        Returns
+        -------
+        th.distributions.Distribution
+            A transformed distribution object derived from the specified base distribution and transformations.
+
         """
         dist = self.base_dist(loc, scale, validate_args=True)  # type: ignore
         transforms = self.transforms(loc.device)
@@ -56,7 +69,14 @@ class BoxDist(spaces.Box):
 
     @classmethod
     def from_space(cls, space: spaces.Box) -> "BoxDist":
-        """Create a BoxDist from a gymnasium Box space."""
+        """Create a BoxDist from a gymnasium Box space.
+
+        Returns
+        -------
+        BoxDist
+            An instance of BoxDist created from the given gymnasium Box space.
+
+        """
         low = space.low
         high = space.high
         dtype = space.dtype

--- a/prob_spaces/converter.py
+++ b/prob_spaces/converter.py
@@ -26,6 +26,12 @@ def convert_to_prob_space(action_space: Spaces) -> DistSpaces:
     :raises NotImplementedError: If the input action space type is not supported.
     :return: The corresponding probability distribution space created based on the input action space
         type.
+
+    Returns
+    -------
+    DistSpaces
+        The corresponding probability distribution space created based on the input action space type.
+
     """
     if isinstance(action_space, gym.spaces.MultiDiscrete):
         space_dist = MultiDiscreteDist.from_space(action_space)

--- a/prob_spaces/discrete.py
+++ b/prob_spaces/discrete.py
@@ -21,6 +21,12 @@ class DiscreteDist(spaces.Discrete):
             of ones if not provided.
         :return: A MaskedCategorical distribution constructed with given probabilities, mask, and
             starting values.
+
+        Returns
+        -------
+        MaskedCategorical
+            A MaskedCategorical distribution constructed with given probabilities, mask, and starting values.
+
         """
         probs = prob.reshape(self.n)  # type: ignore
         start = self.start
@@ -30,7 +36,14 @@ class DiscreteDist(spaces.Discrete):
 
     @classmethod
     def from_space(cls, space: spaces.Discrete) -> "DiscreteDist":
-        """Create a DiscreteDist from a gymnasium Discrete space."""
+        """Create a DiscreteDist from a gymnasium Discrete space.
+
+        Returns
+        -------
+        DiscreteDist
+            An instance of DiscreteDist created from the given gymnasium Discrete space.
+
+        """
         return cls(
             n=space.n,
             start=space.start,

--- a/prob_spaces/dists/categorical.py
+++ b/prob_spaces/dists/categorical.py
@@ -36,7 +36,14 @@ class CategoricalDist(MaskedCategorical):
         self,
         sample_shape: Optional[Union[th.Size, Sequence[int]]] = None,
     ) -> th.Tensor:
-        """Sample from the categorical distribution with start offset."""
+        """Sample from the categorical distribution with start offset.
+
+        Returns
+        -------
+        th.Tensor
+            A tensor containing samples from the categorical distribution, adjusted by the start offset.
+
+        """
         sample = super().sample(sample_shape)
         exact_sample = self._calc_exact(sample, sample_shape)
         return exact_sample
@@ -46,7 +53,14 @@ class CategoricalDist(MaskedCategorical):
         sample: th.Tensor,
         sample_shape: Optional[Union[th.Size, Sequence[int]]],
     ) -> th.Tensor:
-        """Calculate the exact sample with start offset."""
+        """Calculate the exact sample with start offset.
+
+        Returns
+        -------
+        th.Tensor
+            The exact sample tensor, adjusted by the start offset.
+
+        """
         if not isinstance(self.start, np.ndarray) or sum(self.start.shape) == 1:
             exact_sample = sample + self.start  # type: ignore
         else:
@@ -55,5 +69,12 @@ class CategoricalDist(MaskedCategorical):
         return exact_sample  # type: ignore
 
     def log_prob(self, value: torch.Tensor) -> torch.Tensor:
-        """Compute the log probability of a value, accounting for start offset."""
+        """Compute the log probability of a value, accounting for start offset.
+
+        Returns
+        -------
+        torch.Tensor
+            The log probability tensor, accounting for the start offset.
+
+        """
         return super().log_prob(value=value - self.th_start)

--- a/prob_spaces/multi_discrete.py
+++ b/prob_spaces/multi_discrete.py
@@ -30,7 +30,14 @@ class MultiDiscreteDist(spaces.MultiDiscrete):
         return int(np.max(self.nvec)) + 1
 
     def _internal_mask(self) -> NDArray[np.bool_]:
-        """Return internal mask for valid actions in MultiDiscrete space."""
+        """Return internal mask for valid actions in MultiDiscrete space.
+
+        Returns
+        -------
+        NDArray[np.bool_]
+            Internal mask array indicating valid actions in the MultiDiscrete space.
+
+        """
         prob_last_dim = self.prob_last_dim
         shape = (*self.nvec.shape, self.prob_last_dim)
         mask = np.zeros(shape=shape, dtype=np.bool)
@@ -58,6 +65,13 @@ class MultiDiscreteDist(spaces.MultiDiscrete):
         :return: A `MaskedCategorical` distribution object created with reshaped probabilities and
             combined masking information.
         :rtype: MaskedCategorical
+
+        Returns
+        -------
+        MaskedCategorical
+            A `MaskedCategorical` distribution object created with reshaped probabilities and
+            combined masking information.
+
         """
         probs = prob.reshape(*self.nvec.shape, self.prob_last_dim)
         start = self.start
@@ -68,5 +82,12 @@ class MultiDiscreteDist(spaces.MultiDiscrete):
 
     @classmethod
     def from_space(cls, space: spaces.MultiDiscrete) -> "MultiDiscreteDist":
-        """Create a MultiDiscreteDist from a gymnasium MultiDiscrete space."""
+        """Create a MultiDiscreteDist from a gymnasium MultiDiscrete space.
+
+        Returns
+        -------
+        MultiDiscreteDist
+            An instance of MultiDiscreteDist created from the given gymnasium MultiDiscrete space.
+
+        """
         return cls(nvec=space.nvec, dtype=space.dtype, start=space.start)  # type: ignore


### PR DESCRIPTION
This pull request introduces two primary changes: the addition of detailed docstrings to improve code documentation and a minor update to the `Makefile` to include a pre-commit hook installation. The docstrings now follow a consistent format, providing detailed descriptions of return values for various methods across multiple files.

### Documentation Improvements:
* Added detailed docstrings with `Returns` sections to describe the return values for methods in `prob_spaces/box.py`, including `transforms`, `__call__`, and `from_space`. [[1]](diffhunk://#diff-da6ba26481b6479383ec7581675e5028324562227aeae21c0efc6fbc2d162ba2L30-R37) [[2]](diffhunk://#diff-da6ba26481b6479383ec7581675e5028324562227aeae21c0efc6fbc2d162ba2R58-R63) [[3]](diffhunk://#diff-da6ba26481b6479383ec7581675e5028324562227aeae21c0efc6fbc2d162ba2L59-R79)
* Updated docstrings in `prob_spaces/converter.py` for `convert_to_prob_space` to include a `Returns` section for clarity.
* Enhanced docstrings in `prob_spaces/discrete.py` for methods like `__call__` and `from_space` to provide detailed return value descriptions. [[1]](diffhunk://#diff-f033af0e0d032b8001f20abcf51d0c9bb773f5367906f989ec4d49328decfacdR24-R29) [[2]](diffhunk://#diff-f033af0e0d032b8001f20abcf51d0c9bb773f5367906f989ec4d49328decfacdL33-R46)
* Improved documentation in `prob_spaces/dists/categorical.py` for methods such as `sample`, `_calc_exact`, and `log_prob` to explain return types and values. [[1]](diffhunk://#diff-2fffdba6110821c015db5c6e7d3d3b96215f38b005ceac5c66fe5f75eb1995a3L39-R46) [[2]](diffhunk://#diff-2fffdba6110821c015db5c6e7d3d3b96215f38b005ceac5c66fe5f75eb1995a3L49-R63) [[3]](diffhunk://#diff-2fffdba6110821c015db5c6e7d3d3b96215f38b005ceac5c66fe5f75eb1995a3L58-R79)
* Added comprehensive docstrings in `prob_spaces/multi_discrete.py` for methods like `_internal_mask`, `__call__`, and `from_space` to describe return values and improve readability. [[1]](diffhunk://#diff-a5e481043ead8a2878d1e6e008619eb2cdb8601e6d4d71ebd936de56fbfedd01L33-R40) [[2]](diffhunk://#diff-a5e481043ead8a2878d1e6e008619eb2cdb8601e6d4d71ebd936de56fbfedd01R68-R74) [[3]](diffhunk://#diff-a5e481043ead8a2878d1e6e008619eb2cdb8601e6d4d71ebd936de56fbfedd01L71-R92)

### Build Process Update:
* Modified the `Makefile` to include a command for installing pre-commit hooks (`uv run pre-commit install`) in the `install` target. This ensures pre-commit hooks are set up during installation.