### PR TITLE
Add Copilot setup workflows for multiple repositories

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,19 @@
+name: "Copilot Setup Steps"
+
+on: workflow_dispatch
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - run: uv python install 3.11
+      - run: uv sync --all-extras --all-groups --frozen


### PR DESCRIPTION
Introduce a reusable GitHub Actions workflow to streamline Copilot setup across various repositories. This includes setting up `uv`, installing Python 3.11, and syncing dependencies.